### PR TITLE
Added scipy sparse matrix representation for AdjacencyList

### DIFF
--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -1210,6 +1210,10 @@ class AdjacencyList(base.AdjacencyBase):
         sort_idxs = np.argsort(np.abs(unsort_nodes))
         return unsort_nodes[sort_idxs]  # type: ignore
 
+    @cached_property
+    def _sparse(self) -> coo_array:
+        return self.to_sparse()
+
     def to_sparse(self, data: Optional[base.AnyVector] = None) -> coo_array:
         """Converts the graph structure to a ``scipy.sparse.coo_array``
         instance.

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -1210,6 +1210,32 @@ class AdjacencyList(base.AdjacencyBase):
         sort_idxs = np.argsort(np.abs(unsort_nodes))
         return unsort_nodes[sort_idxs]  # type: ignore
 
+    def to_sparse(self, data: Optional[base.AnyVector] = None) -> coo_array:
+        """Converts the graph structure to a ``scipy.sparse.coo_array``
+        instance.
+
+        Parameters
+        ----------
+        data : ndarray, optional
+            Data stored on each edge. If ``None``, these will be boolean
+            values indicating whether the outgoing node is a leaf.
+            Default is ``None``.
+
+        Returns
+        -------
+        arr : scipy.sparse.coo_array
+            COO-formatted sparse array, where rows are "in" and cols
+            are "out" indices for ``AdjacencyList.edges``.
+        """
+        out = self._data["out"]
+        size = np.max(out) + 1
+        if data is None:
+            data = np.sign(self._data["out"]) == 1
+        return coo_array(
+            (data, (np.abs(self._data["in"]), np.abs(self._data["out"]))),
+            shape=(size, size),
+        )
+
     def to_dicts(
         self,
         edge_data: Optional[

--- a/graphicle/select.py
+++ b/graphicle/select.py
@@ -120,8 +120,7 @@ def vertex_descendants(adj: gcl.AdjacencyList, vertex: int) -> gcl.MaskArray:
         Boolean mask over the graphicle objects associated with the
         passed AdjacencyList.
     """
-    sparse = adj.to_sparse()
-    bft = breadth_first_tree(sparse, abs(vertex))
+    bft = breadth_first_tree(adj._sparse, abs(vertex))
     desc_nodes = ((2 * bft.data - 1) * bft.indices).astype("<i4")
     mask = np.isin(adj.edges["in"], desc_nodes)
     mask[adj.edges["in"] == vertex] = True

--- a/graphicle/select.py
+++ b/graphicle/select.py
@@ -9,7 +9,7 @@ from itertools import combinations
 
 import numpy as np
 import pandas as pd
-import networkx as _nx
+from scipy.sparse.csgraph import breadth_first_tree
 
 import graphicle as gcl
 from . import base
@@ -120,11 +120,9 @@ def vertex_descendants(adj: gcl.AdjacencyList, vertex: int) -> gcl.MaskArray:
         Boolean mask over the graphicle objects associated with the
         passed AdjacencyList.
     """
-    graph_dict = adj.to_dicts()
-    vertex = int(vertex)
-    nx_graph = _nx.MultiDiGraph()
-    _ = nx_graph.add_edges_from(graph_dict["edges"])
-    desc_nodes = np.array(list(_nx.descendants(nx_graph, vertex)), dtype="<i4")
+    sparse = adj.to_sparse()
+    bft = breadth_first_tree(sparse, abs(vertex))
+    desc_nodes = ((2 * bft.data - 1) * bft.indices).astype("<i4")
     mask = np.isin(adj.edges["in"], desc_nodes)
     mask[adj.edges["in"] == vertex] = True
     return gcl.MaskArray(mask)


### PR DESCRIPTION
- `AdjacencyList.to_sparse()` method added
- updated `select.vertex_descendants()` to utilise it, rather than networkx, for a speed enhancement