### PR TITLE
Prune tagged jet clusters

### DIFF
--- a/graphicle/calculate.py
+++ b/graphicle/calculate.py
@@ -5,29 +5,20 @@
 Algorithms for performing common HEP calculations using graphicle data
 structures.
 """
-from typing import (
-    Tuple,
-    Optional,
-    Set,
-    List,
-    Dict,
-    Callable,
-    Union,
-    Iterable,
-)
-from functools import lru_cache, partial
 import warnings
+from functools import lru_cache, partial
+from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
+import networkx as nx
 import numpy as np
 import numpy.lib.recfunctions as rfn
-from typicle import Types
-import networkx as nx
 import pyjet
 from pyjet import ClusterSequence, PseudoJet
+from typicle import Types
 
 import graphicle as gcl
-from . import base
 
+from . import base
 
 __all__ = [
     "azimuth_centre",
@@ -62,6 +53,12 @@ def azimuth_centre(pmu: gcl.MomentumArray, pt_weight: bool = True) -> float:
     if pt_weight is True:
         pol = pol * pmu.pt
     return float(np.angle(pol.sum()))
+
+
+def pseudorapidity_centre(pmu: gcl.MomentumArray) -> float:
+    pt_norm = pmu.pt / pmu.pt.sum()
+    eta_wt_mid = (pmu.eta * pt_norm).sum()
+    return eta_wt_mid
 
 
 def combined_mass(

--- a/graphicle/calculate.py
+++ b/graphicle/calculate.py
@@ -12,13 +12,13 @@ import warnings
 from functools import lru_cache, partial
 from typing import Callable, Iterable
 
+import deprecation
 import networkx as nx
 import numba as nb
 import numpy as np
 import numpy.lib.recfunctions as rfn
 import pyjet
 from pyjet import ClusterSequence, PseudoJet
-from typicle import Types
 
 import graphicle as gcl
 
@@ -30,8 +30,6 @@ __all__ = [
     "flow_trace",
     "cluster_pmu",
 ]
-
-_types = Types()
 
 
 def azimuth_centre(pmu: gcl.MomentumArray, pt_weight: bool = True) -> float:
@@ -147,7 +145,7 @@ def _trace_vector(
 ) -> base.AnyVector:
     len_basis = len(basis)
     feat_fmt = rfn.structured_to_unstructured if is_structured else lambda x: x
-    color = np.zeros((len_basis, feat_dim), dtype=_types.double)
+    color = np.zeros((len_basis, feat_dim), dtype="<f8")
     if vertex in basis:
         color[basis.index(vertex)] = 1.0
         if exclusive is True:

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -756,8 +756,12 @@ class MaskGroup(base.MaskBase, cla.MutableMapping[str, base.MaskBase]):
     def __ne__(self, other: base.MaskLike) -> "MaskArray":
         return _mask_neq(self, other)
 
-    def copy(self):
-        return deepcopy(self)
+    def copy(self) -> "MaskGroup":
+        mask_copies = map(op.methodcaller("copy"), self._mask_arrays.values())
+        return self.__class__(
+            cl.OrderedDict(zip(self._mask_arrays.keys(), mask_copies)),
+            agg_op=self._agg_op,  # type: ignore
+        )
 
     @property
     def names(self) -> ty.List[str]:

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -370,9 +370,7 @@ def _array_field(dtype: npt.DTypeLike, num_cols: int = 1):
 
 def _truthy(data: ty.Union[base.ArrayBase, base.AdjacencyBase]) -> bool:
     """Defines the truthy value of the graphicle data structures."""
-    if len(data) == 0:
-        return False
-    return True
+    return not (len(data) == 0)
 
 
 ##################################

--- a/graphicle/select.py
+++ b/graphicle/select.py
@@ -294,7 +294,6 @@ def _partition_vertex(
     final: gcl.MaskArray,
     pmu: gcl.MomentumArray,
     dist_strat: DistFunc,
-    # radius: float,
 ) -> gcl.MaskArray:
     """Prunes input ``mask`` representing hard parton descendants based
     on if final state hadrons are closer to them or background,
@@ -330,10 +329,6 @@ def _partition_vertex(
     final_from_vtx = vtx_desc & final
     hadron_pmu = pmu[final_from_vtx]
     dist = dist_strat(parton_pmu, hadron_pmu)
-    # dist_mask = np.zeros_like(dist, "<?")
-    # parton_idxs = np.flatnonzero(mask[pcls_in])
-    # dist_mask[parton_idxs, :] = dist[parton_idxs, :] > radius
-    # dist[dist_mask] *= 1.0E+6
     alloc = np.argmin(dist, axis=0)
     final_from_hard = np.in1d(alloc, np.flatnonzero(mask[pcls_in]))
     mask.data[final_from_vtx] = final_from_hard
@@ -344,7 +339,6 @@ def partition_descendants(
     graph: gcl.Graphicle,
     hier: gcl.MaskGroup,
     pt_exp: float = -0.1,
-    # radius: float = 0.4,
 ) -> gcl.MaskGroup:
     """Partitions the final state descendants with mixed hard partonic
     heritage, by aligning them with their nearest ancestor.
@@ -391,7 +385,7 @@ def partition_descendants(
                     vtx_desc,
                     graph.final,
                     graph.pmu,
-                    dist_strat,  # radius
+                    dist_strat,
                 ).data
     return hier
 

--- a/graphicle/select.py
+++ b/graphicle/select.py
@@ -736,6 +736,10 @@ def centroid_prune(
     If ``centre`` is not provided, the transverse momentum weighted
     centroid will be used.
 
+    :group: select
+
+    .. versionadded:: 0.2.4
+
     Parameters
     ----------
     pmu : MomentumArray
@@ -743,6 +747,9 @@ def centroid_prune(
     radius : float
         Euclidean distance in the azimuth-pseudorapidity plane from the
         centroid, beyond which particles will be filtered out.
+    mask : MaskArray, optional
+        If provided, will apply the mask to the passed ``pmu``, and
+        output ``MaskArray`` will have the same length.
     centre : tuple[float, float]
         Pseudorapidity and azimuth coordinates for a user-defined
         centroid.

--- a/graphicle/select.py
+++ b/graphicle/select.py
@@ -31,6 +31,7 @@ __all__ = [
     "hadron_vertices",
     "fastjet_clusters",
     "leaf_masks",
+    "centroid_prune",
 ]
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ install_requires =
     pyjet ==1.9.0
     rich
     deprecation
-    more-itertools
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ install_requires =
     pyjet ==1.9.0
     rich
     deprecation
+    more-itertools
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Add utilities to consistently remove outlier data from hierarchy-based Monte-Carlo truth jet clusters, providing robust jet mass, and without breaking IRC safety.