### PR TITLE
Improved array interoperability

### DIFF
--- a/graphicle/base.py
+++ b/graphicle/base.py
@@ -5,12 +5,12 @@
 Defines the base classes, types, and interface protocols used by
 graphicle's modules.
 """
+import collections.abc as cla
 from abc import ABC, abstractmethod
-from typing import Union, Any, Optional, Protocol
+from typing import Any, Optional, Protocol, Union
 
 import numpy as np
 import numpy.typing as npt
-
 
 __all__ = [
     "DoubleVector",
@@ -94,10 +94,14 @@ class EventInterface(Protocol):
         ...
 
 
-class ArrayBase(ABC):
+class ArrayBase(ABC, cla.Sequence, np.lib.mixins.NDArrayOperatorsMixin):
     @abstractmethod
     def __init__(self, data: Optional[AnyVector] = None) -> None:
         pass
+
+    @abstractmethod
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs) -> None:
+        """Defines the way Numpy ufuncs work on the data structure."""
 
     @abstractmethod
     def __len__(self) -> int:
@@ -108,7 +112,7 @@ class ArrayBase(ABC):
         """Truthy returns ``False`` if no elements, ``True`` otherwise."""
 
     @abstractmethod
-    def __array__(self) -> npt.NDArray[Any]:
+    def __array__(self) -> AnyVector:
         """Numpy array representation of the data."""
 
     @property
@@ -155,7 +159,7 @@ class ParticleBase(ABC):
         pass
 
 
-class AdjacencyBase(ABC):
+class AdjacencyBase(ABC, cla.Sequence):
     @abstractmethod
     def __len__(self) -> int:
         pass

--- a/graphicle/base.py
+++ b/graphicle/base.py
@@ -7,7 +7,7 @@ graphicle's modules.
 """
 import collections.abc as cla
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Protocol, Union
+from typing import Any, Optional, Protocol, TypeVar, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -21,6 +21,7 @@ __all__ = [
     "ObjVector",
     "AnyVector",
     "VoidVector",
+    "DoubleUfunc",
     "EventInterface",
     "ArrayBase",
     "ParticleBase",
@@ -38,6 +39,7 @@ ObjVector = npt.NDArray[np.object_]
 AnyVector = npt.NDArray[Any]
 VoidVector = npt.NDArray[np.void]
 MaskLike = Union["MaskBase", BoolVector]
+DoubleUfunc = TypeVar("DoubleUfunc", DoubleVector, np.float64)
 
 
 class EventInterface(Protocol):

--- a/graphicle/base.py
+++ b/graphicle/base.py
@@ -6,8 +6,8 @@ Defines the base classes, types, and interface protocols used by
 graphicle's modules.
 """
 import collections.abc as cla
+import typing as ty
 from abc import ABC, abstractmethod
-from typing import Any, Optional, Protocol, TypeVar, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -36,13 +36,14 @@ BoolVector = npt.NDArray[np.bool_]
 IntVector = npt.NDArray[np.int32]
 HalfIntVector = npt.NDArray[np.int16]
 ObjVector = npt.NDArray[np.object_]
-AnyVector = npt.NDArray[Any]
+AnyVector = npt.NDArray[ty.Any]
 VoidVector = npt.NDArray[np.void]
-MaskLike = Union["MaskBase", BoolVector]
-DoubleUfunc = TypeVar("DoubleUfunc", DoubleVector, np.float64)
+MaskLike = ty.Union["MaskBase", BoolVector]
+DoubleUfunc = ty.TypeVar("DoubleUfunc", DoubleVector, np.float64)
+DataType = ty.TypeVar("DataType")
 
 
-class EventInterface(Protocol):
+class EventInterface(ty.Protocol):
     """Defines the interface for a generic event object expected by
     graphicle's routines. Attributes are stored as numpy arrays, with
     each element corresponding to a particle in an event. Attributes
@@ -100,12 +101,12 @@ class EventInterface(Protocol):
 
 class ArrayBase(ABC, cla.Sequence, np.lib.mixins.NDArrayOperatorsMixin):
     @abstractmethod
-    def __init__(self, data: Optional[AnyVector] = None) -> None:
+    def __init__(self, data: ty.Optional[AnyVector] = None) -> None:
         pass
 
     @abstractmethod
-    def __len__(self) -> int:
-        """Number of elements in array."""
+    def __iter__(self) -> ty.Iterator[ty.Any]:
+        """Iterator exposing contained data as Python native."""
 
     @abstractmethod
     def __bool__(self) -> bool:
@@ -114,6 +115,24 @@ class ArrayBase(ABC, cla.Sequence, np.lib.mixins.NDArrayOperatorsMixin):
     @abstractmethod
     def __array__(self) -> AnyVector:
         """Numpy array representation of the data."""
+
+    @property
+    @abstractmethod
+    def dtype(self) -> AnyVector:
+        """Numpy array representation of the data."""
+
+    @abstractmethod
+    def __eq__(self) -> "MaskBase":
+        """Equality comparison."""
+
+    @abstractmethod
+    def __ne__(self) -> "MaskBase":
+        """Non equality comparison."""
+
+    @property
+    @abstractmethod
+    def _data(self) -> AnyVector:
+        pass
 
     @property
     @abstractmethod
@@ -201,7 +220,7 @@ class MaskBase(ABC):
         pass
 
     @abstractmethod
-    def __array__(self) -> npt.NDArray[Any]:
+    def __array__(self) -> npt.NDArray[ty.Any]:
         """Numpy array representation of the data."""
 
     @abstractmethod

--- a/graphicle/base.py
+++ b/graphicle/base.py
@@ -99,9 +99,9 @@ class ArrayBase(ABC, cla.Sequence, np.lib.mixins.NDArrayOperatorsMixin):
     def __init__(self, data: Optional[AnyVector] = None) -> None:
         pass
 
-    @abstractmethod
-    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs) -> None:
-        """Defines the way Numpy ufuncs work on the data structure."""
+    # @abstractmethod
+    # def __array_ufunc__(self, ufunc, method, *inputs, **kwargs) -> None:
+    #     """Defines the way Numpy ufuncs work on the data structure."""
 
     @abstractmethod
     def __len__(self) -> int:

--- a/graphicle/base.py
+++ b/graphicle/base.py
@@ -20,6 +20,7 @@ __all__ = [
     "HalfIntVector",
     "ObjVector",
     "AnyVector",
+    "VoidVector",
     "EventInterface",
     "ArrayBase",
     "ParticleBase",
@@ -35,6 +36,7 @@ IntVector = npt.NDArray[np.int32]
 HalfIntVector = npt.NDArray[np.int16]
 ObjVector = npt.NDArray[np.object_]
 AnyVector = npt.NDArray[Any]
+VoidVector = npt.NDArray[np.void]
 MaskLike = Union["MaskBase", BoolVector]
 
 

--- a/graphicle/base.py
+++ b/graphicle/base.py
@@ -103,10 +103,6 @@ class ArrayBase(ABC, cla.Sequence, np.lib.mixins.NDArrayOperatorsMixin):
     def __init__(self, data: Optional[AnyVector] = None) -> None:
         pass
 
-    # @abstractmethod
-    # def __array_ufunc__(self, ufunc, method, *inputs, **kwargs) -> None:
-    #     """Defines the way Numpy ufuncs work on the data structure."""
-
     @abstractmethod
     def __len__(self) -> int:
         """Number of elements in array."""

--- a/graphicle/calculate.py
+++ b/graphicle/calculate.py
@@ -5,10 +5,12 @@
 Algorithms for performing common HEP calculations using graphicle data
 structures.
 """
+from __future__ import annotations
+
 import math
 import warnings
 from functools import lru_cache, partial
-from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
+from typing import Callable, Iterable
 
 import networkx as nx
 import numba as nb
@@ -58,8 +60,8 @@ def azimuth_centre(pmu: gcl.MomentumArray, pt_weight: bool = True) -> float:
 
 
 def combined_mass(
-    pmu: Union[gcl.MomentumArray, np.ndarray],
-    weight: Optional[base.DoubleVector] = None,
+    pmu: gcl.MomentumArray | np.ndarray,
+    weight: base.DoubleVector | None = None,
 ) -> float:
     """Returns the combined mass of the particles represented in the
     provided MomentumArray.
@@ -112,7 +114,7 @@ def combined_mass(
     return mass
 
 
-def _diffuse(colors: List[np.ndarray], feats: List[np.ndarray]):
+def _diffuse(colors: list[np.ndarray], feats: list[np.ndarray]):
     color_shape = colors[0].shape
     av_color = np.zeros((color_shape[0], color_shape[1]), dtype="<f8")
     color_stack = np.dstack(colors)  # len_basis x feat_dim x num_in
@@ -132,7 +134,7 @@ def _diffuse(colors: List[np.ndarray], feats: List[np.ndarray]):
 def _trace_vector(
     nx_graph: nx.DiGraph,
     vertex: int,
-    basis: Tuple[int, ...],
+    basis: tuple[int, ...],
     feat_dim: int,
     is_structured: bool,
     exclusive: bool = False,
@@ -145,7 +147,7 @@ def _trace_vector(
         if exclusive is True:
             return color
     in_edges = nx_graph.in_edges(vertex, data=True)
-    colors_in: List[np.ndarray] = []
+    colors_in: list[np.ndarray] = []
     feats = []
     for edge in in_edges:
         feats.append(feat_fmt(edge[2]["feat"]))
@@ -162,11 +164,11 @@ def _trace_vector(
 
 def flow_trace(
     graph: gcl.Graphicle,
-    mask: Union[base.MaskBase, np.ndarray],
-    prop: Union[base.ArrayBase, np.ndarray],
+    mask: base.MaskBase | np.ndarray,
+    prop: base.ArrayBase | np.ndarray,
     exclusive: bool = False,
-    target: Optional[Set[int]] = None,
-) -> Dict[str, np.ndarray]:
+    target: set[int] | None = None,
+) -> dict[str, np.ndarray]:
     """Performs flow tracing from specified particles in an event, back
     to the hard partons.
 
@@ -255,8 +257,8 @@ def cluster_pmu(
     pmu: gcl.MomentumArray,
     radius: float,
     p_val: float,
-    pt_cut: Optional[float] = None,
-    eta_cut: Optional[float] = None,
+    pt_cut: float | None = None,
+    eta_cut: float | None = None,
 ) -> gcl.MaskGroup:
     """Clusters particles using the generalised-kt algorithm.
 

--- a/graphicle/calculate.py
+++ b/graphicle/calculate.py
@@ -5,29 +5,22 @@
 Algorithms for performing common HEP calculations using graphicle data
 structures.
 """
-from typing import (
-    Tuple,
-    Optional,
-    Set,
-    List,
-    Dict,
-    Callable,
-    Union,
-    Iterable,
-)
-from functools import lru_cache, partial
+import math
 import warnings
+from functools import lru_cache, partial
+from typing import Callable, Dict, Iterable, List, Optional, Set, Tuple, Union
 
+import networkx as nx
+import numba as nb
 import numpy as np
 import numpy.lib.recfunctions as rfn
-from typicle import Types
-import networkx as nx
 import pyjet
 from pyjet import ClusterSequence, PseudoJet
+from typicle import Types
 
 import graphicle as gcl
-from . import base
 
+from . import base
 
 __all__ = [
     "azimuth_centre",
@@ -323,3 +316,36 @@ def cluster_pmu(
         mask[list(map(lambda pcl: pcl.idx, jet))] = True  # type: ignore
         cluster_mask[f"{i}"] = mask
     return cluster_mask
+
+
+@nb.vectorize([nb.float64(nb.float64, nb.float64)])
+def _root_diff_two_squares(
+    x1: base.DoubleUfunc, x2: base.DoubleUfunc
+) -> base.DoubleUfunc:
+    """Numpy ufunc to calculate the square rooted difference of two
+    squares.
+
+    Equivalent to ``sign * sqrt(abs(x1**2 - x2**2))``, element-wise.
+    Where `sign` is the +1 or -1 sign associated with the value of the
+    squared difference. This means that root negative squared
+    differences are permitted, but produce negative, rather than
+    imaginary, values.
+    If `x1` or `x2` is scalar_like (ie. unambiguously cast-able to a
+    scalar type), it is broadcast for use with each element of the other
+    argument.
+
+    Parameters
+    ----------
+    x1, x2 : array_like
+        Double precision floating point, or sequence thereof.
+
+    Returns
+    -------
+    z : ndarray | float
+        Root difference of two squares.
+        This is a scalar if both `x1` and `x2` are scalars.
+    """
+    diff = x1 - x2
+    sqrt_diff = math.copysign(math.sqrt(abs(diff)), diff)
+    sqrt_sum = math.sqrt(x1 + x2)
+    return sqrt_diff * sqrt_sum  # type: ignore

--- a/graphicle/calculate.py
+++ b/graphicle/calculate.py
@@ -60,7 +60,7 @@ def azimuth_centre(pmu: gcl.MomentumArray, pt_weight: bool = True) -> float:
 
 
 def combined_mass(
-    pmu: gcl.MomentumArray | np.ndarray,
+    pmu: gcl.MomentumArray | base.VoidVector,
     weight: base.DoubleVector | None = None,
 ) -> float:
     """Returns the combined mass of the particles represented in the
@@ -114,7 +114,7 @@ def combined_mass(
     return mass
 
 
-def _diffuse(colors: list[np.ndarray], feats: list[np.ndarray]):
+def _diffuse(colors: list[base.AnyVector], feats: list[base.AnyVector]):
     color_shape = colors[0].shape
     av_color = np.zeros((color_shape[0], color_shape[1]), dtype="<f8")
     color_stack = np.dstack(colors)  # len_basis x feat_dim x num_in
@@ -138,7 +138,7 @@ def _trace_vector(
     feat_dim: int,
     is_structured: bool,
     exclusive: bool = False,
-) -> np.ndarray:
+) -> base.AnyVector:
     len_basis = len(basis)
     feat_fmt = rfn.structured_to_unstructured if is_structured else lambda x: x
     color = np.zeros((len_basis, feat_dim), dtype=_types.double)
@@ -147,7 +147,7 @@ def _trace_vector(
         if exclusive is True:
             return color
     in_edges = nx_graph.in_edges(vertex, data=True)
-    colors_in: list[np.ndarray] = []
+    colors_in: list[base.AnyVector] = []
     feats = []
     for edge in in_edges:
         feats.append(feat_fmt(edge[2]["feat"]))
@@ -164,11 +164,11 @@ def _trace_vector(
 
 def flow_trace(
     graph: gcl.Graphicle,
-    mask: base.MaskBase | np.ndarray,
-    prop: base.ArrayBase | np.ndarray,
+    mask: base.MaskBase | base.BoolVector,
+    prop: base.ArrayBase | base.AnyVector,
     exclusive: bool = False,
     target: set[int] | None = None,
-) -> dict[str, np.ndarray]:
+) -> dict[str, base.DoubleVector]:
     """Performs flow tracing from specified particles in an event, back
     to the hard partons.
 
@@ -242,7 +242,7 @@ def flow_trace(
     )
     _trace_vector.cache_clear()
     traces = dict()
-    array_fmt: Callable[[np.ndarray], np.ndarray] = (
+    array_fmt: Callable[[base.AnyVector], base.AnyVector] = (
         partial(rfn.unstructured_to_structured, dtype=dtype)  # type: ignore
         if is_structured
         else lambda x: x.squeeze()

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -1508,9 +1508,10 @@ class AdjacencyList(base.AdjacencyBase):
     def __array_wrap__(cls, array: base.AnyVector) -> "AdjacencyList":
         return cls(array)
 
-    def __iter__(self) -> ty.Iterator[ty.Tuple[int, int]]:
+    def __iter__(self) -> ty.Iterator[VertexPair]:
         flat_vals = map(int, it.chain.from_iterable(self._data))
-        yield from zip(*(flat_vals,) * 2, strict=True)  # type: ignore
+        elems = zip(*(flat_vals,) * 2, strict=True)  # type: ignore
+        yield from it.starmap(VertexPair, elems)
 
     def __len__(self) -> int:
         return len(self._data)

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -966,22 +966,26 @@ class MomentumArray(base.ArrayBase):
     def copy(self) -> "MomentumArray":
         return deepcopy(self)
 
-    @fn.cached_property
+    @property
     def _xy_pol(self) -> base.ComplexVector:
-        return self.data["x"] + 1.0j * self.data["y"]  # type: ignore
+        return self._data[:, :2].view(dtype=np.complex128).reshape(-1)
 
     @fn.cached_property
     def _zt_pol(self) -> base.ComplexVector:
-        return self.data["z"] + 1.0j * self.pt  # type: ignore
+        return (
+            np.stack((self.data["z"], np.abs(self._xy_pol)), axis=-1)
+            .view(dtype=np.complex128)
+            .reshape(-1)
+        )
 
     @fn.cached_property
     def _spatial_mag(self) -> base.DoubleVector:
         return np.abs(self._zt_pol)
 
-    @fn.cached_property
+    @property
     def pt(self) -> base.DoubleVector:
         """Momentum component transverse to the beam-axis."""
-        return np.abs(self._xy_pol)
+        return self._zt_pol.imag
 
     @fn.cached_property
     def eta(self) -> base.DoubleVector:

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -942,8 +942,6 @@ class MomentumArray(base.ArrayBase):
     def __array_wrap__(cls, array: base.AnyVector) -> "MomentumArray":
         return cls(array)
 
-    # def __array_ufunc__(self, ufunc, method: str, *inputs, **kwargs):
-
     def __iter__(self) -> ty.Iterator[MomentumElement]:
         flat_vals = map(float, self._data.flatten())
         elems = zip(*(flat_vals,) * 4, strict=True)  # type: ignore

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -1020,11 +1020,9 @@ class MomentumArray(base.ArrayBase):
     @fn.cached_property
     def mass(self) -> base.DoubleVector:
         """Mass of particles."""
-        e: base.DoubleVector = self.data["e"]
-        p = self._spatial_mag
-        sq_diff = e * e - p * p
-        sign = np.sign(sq_diff)
-        return sign * np.sqrt(np.abs(sq_diff))  # type: ignore
+        from .calculate import _root_diff_two_squares
+
+        return _root_diff_two_squares(self.data["e"], self._spatial_mag)
 
     def delta_R(self, other: "MomentumArray") -> base.DoubleVector:
         """Calculates the Euclidean inter-particle distances in the

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -968,13 +968,13 @@ class MomentumArray(base.ArrayBase):
 
     @property
     def _xy_pol(self) -> base.ComplexVector:
-        return self._data[:, :2].view(dtype=np.complex128).reshape(-1)
+        return self._data[:, :2].view(dtype="<c16").reshape(-1)
 
     @fn.cached_property
     def _zt_pol(self) -> base.ComplexVector:
         return (
             np.stack((self.data["z"], np.abs(self._xy_pol)), axis=-1)
-            .view(dtype=np.complex128)
+            .view(dtype="<c16")
             .reshape(-1)
         )
 

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -57,7 +57,7 @@ from rich.tree import Tree
 from scipy.sparse import coo_array
 from typicle import Types
 
-from . import base
+from . import base, calculate
 
 __all__ = [
     "MaskAggOp",
@@ -1020,9 +1020,9 @@ class MomentumArray(base.ArrayBase):
     @fn.cached_property
     def mass(self) -> base.DoubleVector:
         """Mass of particles."""
-        from .calculate import _root_diff_two_squares
-
-        return _root_diff_two_squares(self.data["e"], self._spatial_mag)
+        return calculate._root_diff_two_squares(
+            self.data["e"], self._spatial_mag
+        )
 
     def delta_R(self, other: "MomentumArray") -> base.DoubleVector:
         """Calculates the Euclidean inter-particle distances in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,14 @@ warn_return_any = true
 warn_unreachable = true
 warn_unused_configs = true
 no_implicit_reexport = true
+
+[tool.pyright]
+include = ["graphicle"]
+exclude = ["**/node_modules", "**/__pycache__"]
+defineConstant = { DEBUG = true }
+
+reportMissingImports = true
+reportMissingTypeStubs = false
+
+pythonVersion = "3.8"
+pythonPlatform = "Linux"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     attrs
     numpy >=1.21
     scipy >=1.8.0
+    numba
     mcpid
     typicle >=0.1.4
     networkx


### PR DESCRIPTION
Define iterators over the array objects, add [numpy interfaces](https://numpy.org/doc/stable/user/basics.interoperability.html#basics-interoperability), and inherit the [numpy mixin base class](https://numpy.org/doc/stable/reference/generated/numpy.lib.mixins.NDArrayOperatorsMixin.html) for class special methods to get the numpy array-like operations for free.