### PR TITLE
Migrated FastJet interface to select module

### DIFF
--- a/graphicle/calculate.py
+++ b/graphicle/calculate.py
@@ -12,6 +12,7 @@ import warnings
 from functools import lru_cache, partial
 from typing import Callable, Iterable
 
+import deprecation
 import networkx as nx
 import numba as nb
 import numpy as np
@@ -253,6 +254,11 @@ def flow_trace(
     return traces
 
 
+@deprecation.deprecated(
+    deprecated_in="0.2.3",
+    removed_in="0.3.0",
+    details="Use ``graphicle.select.fastjet_clusters()`` instead.",
+)
 def cluster_pmu(
     pmu: gcl.MomentumArray,
     radius: float,

--- a/graphicle/select.py
+++ b/graphicle/select.py
@@ -91,7 +91,7 @@ def fastjet_clusters(
         anti-kt algorithm: p_val = -1
 
     .. versionadded:: 0.2.3
-    Provides an interface to FastJet clustering.
+    Migrated from ``graphicle.calculate.cluster_pmu()``.
     """
     pmu_pyjet = pmu.data[["e", "x", "y", "z"]]
     pmu_pyjet.dtype.names = "E", "px", "py", "pz"

--- a/graphicle/select.py
+++ b/graphicle/select.py
@@ -78,7 +78,7 @@ def fastjet_clusters(
     Returns
     -------
     clusters : list[MaskArray]
-        Deque containing masks over the input data for each jet
+        List containing masks over the input data for each jet
         clustering.
 
     Notes

--- a/graphicle/select.py
+++ b/graphicle/select.py
@@ -79,7 +79,7 @@ def fastjet_clusters(
     -------
     clusters : list[MaskArray]
         List containing masks over the input data for each jet
-        clustering.
+        clustering, in order of descending transverse momentum.
 
     Notes
     -----

--- a/graphicle/select.py
+++ b/graphicle/select.py
@@ -85,10 +85,8 @@ def fastjet_clusters(
     -----
     This is a wrapper around FastJet's implementation.
 
-    Standard settings:
-        kt algorithm: p_val = 1
-        Cambridge/Aachen algorithm: p_val = 0
-        anti-kt algorithm: p_val = -1
+    ``p_val`` set to ``-1`` gives anti-kT, ``0`` gives Cambridge-Aachen,
+    and ``1`` gives kT clusterings.
 
     .. versionadded:: 0.2.3
     Migrated from ``graphicle.calculate.cluster_pmu()``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ install_requires =
     networkx
     pyjet ==1.9.0
     rich
+    deprecation
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
- FastJet clustering moved into select module
- Output given as a list of `MaskArray` instances, rather than `MaskGroup`