### PR TITLE
AdjacencyList methods robust to subscripting

### DIFF
--- a/graphicle/base.py
+++ b/graphicle/base.py
@@ -178,7 +178,7 @@ class ParticleBase(ABC):
         pass
 
 
-class AdjacencyBase(ABC, cla.Sequence):
+class AdjacencyBase(ABC, cla.Sequence, np.lib.mixins.NDArrayOperatorsMixin):
     @abstractmethod
     def __len__(self) -> int:
         pass

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -1847,7 +1847,7 @@ class AdjacencyList(base.AdjacencyBase):
         adj[abs_edges[:, 0], abs_edges[:, 1]] = weights
         return adj
 
-    @property
+    @fn.cached_property
     def _edge_relabel(self) -> base.IntVector:
         _, inv = np.unique(self._data, return_inverse=True)
         return inv.reshape(-1, 2)

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -77,6 +77,7 @@ __all__ = [
     "Graphicle",
 ]
 
+
 ###########################################
 # SET UP ARRAY ATTRIBUTES FOR DATACLASSES #
 ###########################################
@@ -1849,9 +1850,7 @@ class AdjacencyList(base.AdjacencyBase):
     @property
     def _edge_relabel(self) -> base.IntVector:
         _, inv = np.unique(self._data, return_inverse=True)
-        size = np.max(inv) + 1
-        new_idxs = np.arange(size, dtype="<i4")
-        return new_idxs[inv].reshape(-1, 2)
+        return inv.reshape(-1, 2)
 
     @property
     def data(self) -> base.VoidVector:


### PR DESCRIPTION
Fixed the `AdjacencyList` subscripting issues when using `AdjacencyList.to_sparse()` and `AdjacencyList.matrix`. Added a protected attribute to relabel the edge indices when subscripted.