### PR TITLE
Patch: vertex_descendants robust to no descendants #112

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,6 +6,8 @@
 
 # -- Path setup --------------------------------------------------------------
 
+import inspect
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -14,13 +16,12 @@
 # import sys
 # sys.path.insert(0, os.path.abspath("."))
 from importlib.metadata import version as get_version
-from typing import Optional, Dict, Any
 from pathlib import Path
-import inspect
+from typing import Any, Dict, Optional
 
-import graphicle as proj_pkg
 from pygit2 import Repository
 
+import graphicle as proj_pkg
 
 # -- Project information -----------------------------------------------------
 
@@ -73,6 +74,8 @@ autodoc_typehints_format = "short"
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
+    "numpy [stable]": ("https://numpy.org/doc/stable/", None),
+    "scipy [latest]": ("https://docs.scipy.org/doc/scipy/", None),
 }
 intersphinx_disabled_domains = ["std"]
 

--- a/graphicle/select.py
+++ b/graphicle/select.py
@@ -211,9 +211,8 @@ def vertex_descendants(adj: gcl.AdjacencyList, vertex: int) -> gcl.MaskArray:
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.7
-       In the edge case of no descendants, now returns a mask particles
-       with the vertex id as the edge destination. Previously this
-       raised an unhandled ``IndexError``.
+       In the edge case of no descendants, now returns a mask with just
+       the parent, rather than raising an unhandled ``IndexError``.
 
     Parameters
     ----------

--- a/graphicle/select.py
+++ b/graphicle/select.py
@@ -204,7 +204,7 @@ def find_vertex(
 
 def vertex_descendants(adj: gcl.AdjacencyList, vertex: int) -> gcl.MaskArray:
     """Returns a ``MaskArray`` to select particles which descend from a
-    given interaction vertex.
+    given interaction vertex. This mask includes the parent vertex.
 
     :group: select
 


### PR DESCRIPTION
`select.vertex_descendants()` already included the parent vertex in the output mask. When there were no children, it raised an unhandled `IndexError`. This behaviour has been squashed by simply returning the mask containing the passed vertex, which would have been the parent element in the regular use case.