### PR TITLE
Downgrade syntax to Python 3.8

### DIFF
--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -442,7 +442,7 @@ class MaskArray(base.MaskBase, base.ArrayBase):
         return _array_ufunc(self, ufunc, method, *inputs, **kwargs)
 
     def __iter__(self) -> ty.Iterator[bool]:
-        yield from map(bool, self.data)
+        return map(bool, self.data)
 
     def copy(self) -> "MaskArray":
         return self.__class__(self._data.copy())
@@ -705,6 +705,8 @@ class MaskGroup(base.MaskBase, cla.MutableMapping[str, MaskGeneric]):
         self._mask_arrays.update({key: mask})
 
     def __bool__(self) -> bool:
+        if len(self) == 0:
+            return False
         if np.shape(self.data)[0] == 0:
             return False
         return True

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -1143,7 +1143,7 @@ class MomentumArray(base.ArrayBase):
 
     def __iter__(self) -> ty.Iterator[MomentumElement]:
         flat_vals = map(float, self._data.flatten())
-        elems = zip(*(flat_vals,) * 4, strict=True)  # type: ignore
+        elems = zip(*(flat_vals,) * 4)  # type: ignore
         yield from it.starmap(MomentumElement, elems)
 
     def __len__(self) -> int:
@@ -1346,7 +1346,7 @@ class ColorArray(base.ArrayBase):
 
     def __iter__(self) -> ty.Iterator[ColorElement]:
         flat_vals = map(int, it.chain.from_iterable(self.data))
-        elems = zip(*(flat_vals,) * 2, strict=True)  # type: ignore
+        elems = zip(*(flat_vals,) * 2)
         yield from it.starmap(ColorElement, elems)
 
     @property
@@ -1824,7 +1824,7 @@ class AdjacencyList(base.AdjacencyBase):
 
     def __iter__(self) -> ty.Iterator[VertexPair]:
         flat_vals = map(int, it.chain.from_iterable(self._data))
-        elems = zip(*(flat_vals,) * 2, strict=True)  # type: ignore
+        elems = zip(*(flat_vals,) * 2)
         yield from it.starmap(VertexPair, elems)
 
     def __len__(self) -> int:

--- a/graphicle/select.py
+++ b/graphicle/select.py
@@ -40,6 +40,16 @@ DistFunc = ty.Callable[
 ]
 
 
+def _param_check(
+    param: ty.Any, name: str, expected: ty.Type
+) -> ty.Optional[ty.NoReturn]:
+    if not isinstance(param, expected):
+        received = type(param)
+        raise ValueError(
+            f"Expected {name} to be {expected}. Received {received}."
+        )
+
+
 def fastjet_clusters(
     pmu: gcl.MomentumArray,
     radius: float,
@@ -91,6 +101,7 @@ def fastjet_clusters(
     ``p_val`` set to ``-1`` gives **anti-kT**, ``0`` gives
     **Cambridge-Aachen**, and ``1`` gives **kT** clusterings.
     """
+    _param_check(pmu, "pmu", gcl.MomentumArray)
     pmu_pyjet = pmu.data[["e", "x", "y", "z"]]
     pmu_pyjet.dtype.names = "E", "px", "py", "pz"
     pmu_pyjet_idx = rfn.append_fields(
@@ -895,6 +906,7 @@ def centroid_prune(
         Mask which retains only the particles within ``radius`` of the
         centroid.
     """
+    _param_check(pmu, "pmu", gcl.MomentumArray)
     if mask is not None:
         pmu = pmu[mask]
         event_mask = np.zeros_like(mask, "<?")


### PR DESCRIPTION
Python 3.10 syntax crept into usage of `zip()` with the kwarg `strict`. Removed this.
Additionally, added a check to prevent passing numpy arrays for `pmu` params in the `select` module.