### PR TITLE
Patched one last strict kwarg in zip

### DIFF
--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -591,7 +591,7 @@ MaskGeneric = ty.TypeVar(
 
 
 @define
-class MaskGroup(base.MaskBase, cla.MutableMapping[str, MaskGeneric]):
+class MaskGroup(base.MaskBase, ty.MutableMapping[str, MaskGeneric]):
     """Data structure to compose groups of masks over particle arrays.
     Can be nested to form complex hierarchies.
 

--- a/graphicle/select.py
+++ b/graphicle/select.py
@@ -671,7 +671,7 @@ def hard_descendants(
     pcl_out_vtxs = map(int, hard_graph.edges["out"])
     descs = map(vertex_descendants, it.repeat(graph.adj), pcl_out_vtxs)
     group = gcl.MaskGroup(cl.OrderedDict(zip(pdg_keys, descs)), agg_op="or")
-    for key, idx in zip(pdg_keys, np.flatnonzero(hard_mask), strict=True):
+    for key, idx in zip(pdg_keys, np.flatnonzero(hard_mask)):
         group[key][idx] = True
     return group
 

--- a/graphicle/select.py
+++ b/graphicle/select.py
@@ -1004,7 +1004,7 @@ def color_singlets(
     colored_mask = tuple(map(op.ne, it.repeat((0, 0)), colors))
     colored_only = it.compress(colors, colored_mask)
     keys = tuple(it.compress(leaves.keys(), colored_mask))
-    named_colors = tuple(zip(keys, colored_only, strict=True))  # type: ignore
+    named_colors = tuple(zip(keys, colored_only))
     combos = it.chain(
         it.combinations(named_colors, 2), it.combinations(named_colors, 3)
     )


### PR DESCRIPTION
Patch for `0.2.9` was incomplete, found one more strict kwarg in a zip call.
Also replaced non subscriptable mutable mapping from `collections.abc` with `typing.MutableMapping`, which is subscriptable.