### PR TITLE
Tag clusters to partons in hard process with MC truth #136

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,7 +58,12 @@ extensions = [
     "sphinx_immaterial",
     "sphinx_immaterial.apidoc.python.apigen",
     "sphinx.ext.linkcode",
+    "sphinx.ext.extlinks",
 ]
+
+extlinks = {
+    "doi": ("https://dx.doi.org/%s", "doi:%s"),
+}
 
 autoapi_dirs = [proj_dir]
 autodoc_default_options = {

--- a/graphicle/calculate.py
+++ b/graphicle/calculate.py
@@ -6,7 +6,10 @@ Algorithms for performing common HEP calculations using graphicle data
 structures.
 """
 import contextlib as ctx
+import functools as fn
+import itertools as it
 import math
+import operator as op
 import typing as ty
 import warnings
 from functools import lru_cache, partial
@@ -31,6 +34,7 @@ __all__ = [
     "combined_mass",
     "flow_trace",
     "cluster_pmu",
+    "aggregate_momenta",
 ]
 
 
@@ -498,3 +502,31 @@ def _thread_scope(num_threads: int):
         yield None
     finally:
         nb.set_num_threads(prev_threads)
+
+
+def aggregate_momenta(
+    pmu: "MomentumArray", clusters: ty.Iterable["MaskArray"]
+) -> "MomentumArray":
+    """Calculates the aggregate momenta for a sequence of clusters over
+    the same point cloud of particles.
+
+    .. versionadded:: 0.2.14
+
+    Parameters
+    ----------
+    pmu : MomentumArray
+        Four-momenta of particles in the point cloud.
+    clusters : Iterable[MaskArray]
+        Iterable of boolean masks identifying which particles belong
+        to each of the clusterings.
+
+    Returns
+    -------
+    MomentumArray
+        Where each element represents the sum aggregate four-momenta of
+        each cluster, in the same order passed via ``clusters``.
+    """
+    momentum_class = type(pmu)
+    pmus = map(fn.partial(op.getitem, pmu), clusters)
+    pmu_sums = map(fn.partial(np.sum, axis=0), pmus)
+    return momentum_class(list(it.chain.from_iterable(pmu_sums)))

--- a/graphicle/calculate.py
+++ b/graphicle/calculate.py
@@ -505,10 +505,12 @@ def _thread_scope(num_threads: int):
 
 
 def aggregate_momenta(
-    pmu: "MomentumArray", clusters: ty.Iterable["MaskArray"]
+    pmu: "MomentumArray", cluster_masks: ty.Iterable["MaskArray"]
 ) -> "MomentumArray":
     """Calculates the aggregate momenta for a sequence of clusters over
     the same point cloud of particles.
+
+    :group: calculate
 
     .. versionadded:: 0.2.14
 
@@ -516,9 +518,9 @@ def aggregate_momenta(
     ----------
     pmu : MomentumArray
         Four-momenta of particles in the point cloud.
-    clusters : Iterable[MaskArray]
-        Iterable of boolean masks identifying which particles belong
-        to each of the clusterings.
+    cluster_masks : Iterable[MaskArray]
+        Iterable of boolean masks identifying which particles belong to
+        each of the clusterings.
 
     Returns
     -------
@@ -527,6 +529,6 @@ def aggregate_momenta(
         each cluster, in the same order passed via ``clusters``.
     """
     momentum_class = type(pmu)
-    pmus = map(fn.partial(op.getitem, pmu), clusters)
+    pmus = map(fn.partial(op.getitem, pmu), cluster_masks)
     pmu_sums = map(fn.partial(np.sum, axis=0), pmus)
     return momentum_class(list(it.chain.from_iterable(pmu_sums)))

--- a/graphicle/select.py
+++ b/graphicle/select.py
@@ -1223,6 +1223,9 @@ def monte_carlo_tag(
         If ``intermediate`` and ``outgoing`` are simultaneously set to
         ``False``, or ``blacklist`` and ``whitelist`` are simultaneously
         not ``None``.
+    IndexError
+        If after applying ``blacklist`` or ``whitelist``, no matching
+        partons remain in the hard process.
     """
     portions = []
     if outgoing:
@@ -1244,6 +1247,8 @@ def monte_carlo_tag(
             hard_pdg_ = np.abs(hard_pdg_)
             list_ = np.abs(list_)
         hard_mask = np.isin(hard_pdg_, list_, invert=(whitelist is None))
+        if not np.any(hard_mask):
+            raise IndexError("No partons matching filters found.")
         hard_pmu = hard_pmu[hard_mask]
         hard_pdg = hard_pdg[hard_mask]
     cluster_pmu = gcl.calculate.aggregate_momenta(


### PR DESCRIPTION
Add ability to assign tags to arbitrary clusters from intermediate / outgoing partons in the Monte-Carlo truth.