### PR TITLE
Relabel edges from in / out to src / dst #140

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish to PyPI
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with: { fetch-depth: 0 }

--- a/graphicle/base.py
+++ b/graphicle/base.py
@@ -67,7 +67,7 @@ class EventInterface(ty.Protocol):
         Status codes annotating particles describing their generation.
     final : ndarray[bool_]
         Mask identifying final particles in the event's ancestry.
-    edges : ndarray[int32], fields ("in", "out")
+    edges : ndarray[int32], fields ("src", "dst")
         Ancestry of particles in event, encoded as a COO list of
         integers, describing a graph structure.
     """

--- a/graphicle/calculate.py
+++ b/graphicle/calculate.py
@@ -280,9 +280,9 @@ def flow_trace(
             list(target), blacklist=False, sign_sensitive=True
         )
         hard_graph = hard_graph[target_mask]
-    names, vtxs = tuple(hard_graph.pdg.name), tuple(hard_graph.edges["out"])
+    names, vtxs = tuple(hard_graph.pdg.name), tuple(hard_graph.edges["dst"])
     # out vertices of user specified particles
-    focus_pcls = graph.edges[mask]["out"]
+    focus_pcls = graph.edges[mask]["dst"]
     trc = np.array(
         [
             _trace_vector(

--- a/graphicle/calculate.py
+++ b/graphicle/calculate.py
@@ -14,13 +14,10 @@ import typing as ty
 import warnings
 from functools import lru_cache, partial
 
-import deprecation
 import networkx as nx
 import numba as nb
 import numpy as np
 import numpy.lib.recfunctions as rfn
-import pyjet
-from pyjet import ClusterSequence, PseudoJet
 
 from . import base
 
@@ -33,7 +30,6 @@ __all__ = [
     "rapidity_centre",
     "combined_mass",
     "flow_trace",
-    "cluster_pmu",
     "aggregate_momenta",
 ]
 
@@ -302,80 +298,6 @@ def flow_trace(
     for i, name in enumerate(names):
         traces[name] = array_fmt(trc[:, i, :])
     return traces
-
-
-@deprecation.deprecated(
-    deprecated_in="0.2.3",
-    removed_in="0.3.0",
-    details="Use ``graphicle.select.fastjet_clusters()`` instead.",
-)
-def cluster_pmu(
-    pmu: "MomentumArray",
-    radius: float,
-    p_val: float,
-    pt_cut: ty.Optional[float] = None,
-    eta_cut: ty.Optional[float] = None,
-) -> "MaskGroup":
-    """Clusters particles using the generalised-kt algorithm.
-
-    :group: calculate
-
-    .. versionadded:: 0.1.4
-
-    Parameters
-    ----------
-    pmu: MomentumArray
-        The momenta of each particle in the point cloud.
-    radius : float
-        The radius of the clusters to be produced.
-    p_val : float
-        The exponent parameter determining the transverse momentum (pt)
-        dependence of iterative pseudojet merges. Positive values
-        cluster low pt particles first, positive values cluster high pt
-        particles first, and a value of zero corresponds to no pt
-        dependence.
-    pt_cut : float, optional
-        Jet transverse momentum threshold, below which jets will be
-        discarded.
-    eta_cut : float, optional
-        Jet pseudorapidity threshold, above which jets will be
-        discarded.
-
-    Returns
-    -------
-    clusters : MaskGroup
-        MaskGroup object, containing boolean masks over the input data
-        for each jet clustering.
-
-    Notes
-    -----
-    This is a wrapper around FastJet's implementation.
-
-    ``p_val`` set to ``-1`` gives anti-kT, ``0`` gives Cambridge-Aachen,
-    and ``1`` gives kT clusterings.
-    """
-    from graphicle.data import MaskGroup
-
-    pmu_pyjet = pmu.data[["e", "x", "y", "z"]]
-    pmu_pyjet.dtype.names = "E", "px", "py", "pz"
-    pmu_pyjet_idx = rfn.append_fields(
-        pmu_pyjet, "idx", np.arange(len(pmu_pyjet))
-    )
-    sequence: ClusterSequence = pyjet.cluster(
-        pmu_pyjet_idx, R=radius, p=p_val, ep=True
-    )
-    jets: ty.Iterable[PseudoJet] = sequence.inclusive_jets()
-    if pt_cut is not None:
-        jets = filter(lambda jet: jet.pt > pt_cut, jets)
-    if eta_cut is not None:
-        jets = filter(lambda jet: abs(jet.eta) < eta_cut, jets)
-    cluster_mask = MaskGroup()
-    cluster_mask.agg_op = "or"
-    for i, jet in enumerate(jets):
-        mask = np.zeros_like(pmu_pyjet, dtype="<?")
-        mask[list(map(lambda pcl: pcl.idx, jet))] = True  # type: ignore
-        cluster_mask[f"{i}"] = mask
-    return cluster_mask
 
 
 @nb.vectorize([nb.float64(nb.float64, nb.float64)])

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -2063,7 +2063,7 @@ class AdjacencyList(base.AdjacencyBase):
     ----------
     data : ndarray[int32] or ndarray[void]
         COO formatted edge pairs, either given as a (n-2)-dimensional
-        array, or a structured array with field names ``('in', 'out')``.
+        array, or a structured array with field names ``('src', 'dst')``.
     weights : np.ndarray[float64]
         Weights attributed to each edge in the COO list.
 
@@ -2165,7 +2165,7 @@ class AdjacencyList(base.AdjacencyBase):
 
     @property
     def edges(self) -> base.VoidVector:
-        """COO edge list, with field names ``('in', 'out')``."""
+        """COO edge list, with field names ``('src', 'dst')``."""
         return self.data
 
     @property
@@ -2481,7 +2481,7 @@ class Graphicle:
             COO formatted pairs of vertex ids, of shape ``(N, 2)``,
             where ``N`` is the number of particles in the graph.
             Alternatively, supply a structured array with field names
-            ``('in', 'out')``.
+            ``('src', 'dst')``.
         weights : ndarray[Number], optional
             Weights to be associated with each edge in the COO edge
             list, provided in the same order.
@@ -2551,7 +2551,7 @@ class Graphicle:
 
     @property
     def edges(self) -> base.VoidVector:
-        """COO edge list, with field names ``('in', 'out')``."""
+        """COO edge list, with field names ``('src', 'dst')``."""
         return self.adj.edges
 
     @property

--- a/graphicle/transform.py
+++ b/graphicle/transform.py
@@ -70,8 +70,8 @@ def particle_as_node(adj_list: gcl.AdjacencyList) -> gcl.AdjacencyList:
     # node labels set as particle indices in original edge array
     for i, node_triplet in enumerate(edges_as_nodes):
         key = node_triplet["key"]
-        node = node_triplet[["in", "out"]]
-        sign = -1 * check_sign(node["in"] * node["out"])
+        node = node_triplet[["src", "dst"]]
+        sign = -1 * check_sign(node["src"] * node["dst"])
         node_idxs[i] = sign * (np.where(edges == node)[0][key] + 1)
     nx_node_graph = _nx.relabel_nodes(
         nx_node_graph,


### PR DESCRIPTION
Makes graphicle consistent with showerpipe's improved naming scheme for edge labels, referring to node ids as "src" and "dst" rather than the contextually ambiguous "in" and "out". Arrays passed to the `AdjacencyList` instantiator will still accept "in" and "out" structured fields, but will convert them to "src" and "dst" in the process. Direct access of the underlying array will therefore result in breaking changes, if subscripting with the old field names.