### PR TITLE
Added serialize methods to data structures #148

### DIFF
--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -1977,9 +1977,9 @@ def _composite_copy(instance: CompositeGeneric) -> CompositeGeneric:
 class ParticleSetSerialized(tyx.TypedDict, total=False):
     """Typed dictionary format of a serialized ParticleSet instance.
 
-    .. versionadded:: 0.3.2
-
     :group: datastructure
+
+    .. versionadded:: 0.3.2
     """
 
     pdg: ty.List[int]
@@ -2379,9 +2379,9 @@ class AdjacencyList(base.AdjacencyBase):
 class GraphicleSerialized(tyx.TypedDict, total=False):
     """Typed dictionary format of a serialized Graphicle instance.
 
-    .. versionadded:: 0.3.2
-
     :group: datastructure
+
+    .. versionadded:: 0.3.2
     """
 
     pdg: ty.List[int]

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -76,9 +76,11 @@ __all__ = [
     "HelicityArray",
     "StatusArray",
     "ParticleSet",
+    "ParticleSetSerialized",
     "AdjacencyList",
     "VertexPair",
     "Graphicle",
+    "GraphicleSerialized",
 ]
 
 

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -120,9 +120,9 @@ _EDGE_ORDER = ("src", "dst")
 class MomentumElement(ty.NamedTuple):
     """Named tuple container for the four-momentum of a single particle.
 
-    :group: datastructure
-
     .. versionadded:: 0.2.0
+
+    :group: datastructure
     """
 
     x: float
@@ -135,9 +135,9 @@ class ColorElement(ty.NamedTuple):
     """Named tuple container for the color / anticolor pair of a single
     particle.
 
-    :group: datastructure
-
     .. versionadded:: 0.2.0
+
+    :group: datastructure
     """
 
     color: int
@@ -148,9 +148,9 @@ class VertexPair(ty.NamedTuple):
     """Named tuple container for the color / anticolor pair of a single
     particle.
 
-    :group: datastructure
-
     .. versionadded:: 0.2.0
+
+    :group: datastructure
     """
 
     src: int
@@ -403,12 +403,12 @@ def _truthy(data: ty.Union[base.ArrayBase, base.AdjacencyBase]) -> bool:
 class MaskArray(base.MaskBase, base.ArrayBase):
     """Boolean mask over Graphicle data structures.
 
-    :group: datastructure
-
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.0
        Added internal numpy interfaces for greater interoperability.
+
+    :group: datastructure
 
     Parameters
     ----------
@@ -616,13 +616,14 @@ class MaskGroup(base.MaskBase, ty.MutableMapping[str, MaskGeneric]):
     """Data structure to compose groups of masks over particle arrays.
     Can be nested to form complex hierarchies.
 
-    :group: datastructure
-
     .. versionadded:: 0.1.0
+
     .. versionchanged:: 0.2.6
        Changed ``bitwise_or`` and ``bitwise_and`` properties into
        methods.
        Added generic type hinting for elements within ``MaskGroup``.
+
+    :group: datastructure
 
     Parameters
     ----------
@@ -917,12 +918,12 @@ class PdgArray(base.ArrayBase):
     """Returns data structure containing PDG integer codes for particle
     data.
 
-    :group: datastructure
-
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.0
        Added internal numpy interfaces for greater interoperability.
+
+    :group: datastructure
 
     Parameters
     ----------
@@ -1182,8 +1183,6 @@ class PdgArray(base.ArrayBase):
 class MomentumArray(base.ArrayBase):
     """Data structure containing four-momentum of particle list.
 
-    :group: datastructure
-
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.0
@@ -1194,6 +1193,8 @@ class MomentumArray(base.ArrayBase):
 
     .. versionchanged:: 0.2.11
        Added ``mass_t`` attribute.
+
+    :group: datastructure
 
     Parameters
     ----------
@@ -1603,12 +1604,12 @@ class ColorArray(base.ArrayBase):
     """Returns data structure of color / anti-color pairs for particle
     shower.
 
-    :group: datastructure
-
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.0
        Added internal numpy interfaces for greater interoperability.
+
+    :group: datastructure
 
     Parameters
     ----------
@@ -1700,12 +1701,12 @@ class HelicityArray(base.ArrayBase):
     """Data structure containing helicity / polarisation values for
     particle set.
 
-    :group: datastructure
-
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.0
        Added internal numpy interfaces for greater interoperability.
+
+    :group: datastructure
 
     Parameters
     ----------
@@ -1787,12 +1788,12 @@ class HelicityArray(base.ArrayBase):
 class StatusArray(base.ArrayBase):
     """Data structure containing status values for particle set.
 
-    :group: datastructure
-
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.0
        Added internal numpy interfaces for greater interoperability.
+
+    :group: datastructure
 
     Parameters
     ----------
@@ -1987,9 +1988,9 @@ class ParticleSetSerialized(tyx.TypedDict, total=False):
 class ParticleSet(base.ParticleBase):
     """Composite of data structures containing particle set description.
 
-    :group: datastructure
-
     .. versionadded:: 0.1.0
+
+    :group: datastructure
 
     Parameters
     ----------
@@ -2114,8 +2115,6 @@ class AdjacencyList(base.AdjacencyBase):
     """Describes relations between particles in particle set using a
     COO edge list, and provides methods to convert representation.
 
-    :group: datastructure
-
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.4
@@ -2123,6 +2122,8 @@ class AdjacencyList(base.AdjacencyBase):
 
     .. versionchanged:: 0.3.0
        Renamed "in" / "out" fields to "src" / "dst".
+
+    :group: datastructure
 
     Parameters
     ----------
@@ -2384,12 +2385,12 @@ class Graphicle:
     """Composite object, combining particle set data with relational
     information between particles.
 
-    :group: datastructure
-
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.4
        Removed ``hard_vertex`` attribute.
+
+    :group: datastructure
 
     Parameters
     ----------

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -1976,6 +1976,13 @@ def _composite_copy(instance: CompositeGeneric) -> CompositeGeneric:
 
 
 class ParticleSetSerialized(tyx.TypedDict, total=False):
+    """Typed dictionary format of a serialized ParticleSet instance.
+
+    .. versionadded:: 0.3.2
+
+    :group: datastructure
+    """
+
     pdg: ty.List[int]
     pmu: ty.List[ty.Tuple[float, float, float, float]]
     color: ty.List[ty.Tuple[int, int]]
@@ -2371,6 +2378,13 @@ class AdjacencyList(base.AdjacencyBase):
 
 
 class GraphicleSerialized(tyx.TypedDict, total=False):
+    """Typed dictionary format of a serialized Graphicle instance.
+
+    .. versionadded:: 0.3.2
+
+    :group: datastructure
+    """
+
     pdg: ty.List[int]
     pmu: ty.List[ty.Tuple[float, float, float, float]]
     color: ty.List[ty.Tuple[int, int]]

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -120,9 +120,9 @@ _EDGE_ORDER = ("src", "dst")
 class MomentumElement(ty.NamedTuple):
     """Named tuple container for the four-momentum of a single particle.
 
-    .. versionadded:: 0.2.0
-
     :group: datastructure
+
+    .. versionadded:: 0.2.0
     """
 
     x: float
@@ -135,9 +135,9 @@ class ColorElement(ty.NamedTuple):
     """Named tuple container for the color / anticolor pair of a single
     particle.
 
-    .. versionadded:: 0.2.0
-
     :group: datastructure
+
+    .. versionadded:: 0.2.0
     """
 
     color: int
@@ -148,9 +148,9 @@ class VertexPair(ty.NamedTuple):
     """Named tuple container for the color / anticolor pair of a single
     particle.
 
-    .. versionadded:: 0.2.0
-
     :group: datastructure
+
+    .. versionadded:: 0.2.0
     """
 
     src: int
@@ -403,12 +403,12 @@ def _truthy(data: ty.Union[base.ArrayBase, base.AdjacencyBase]) -> bool:
 class MaskArray(base.MaskBase, base.ArrayBase):
     """Boolean mask over Graphicle data structures.
 
+    :group: datastructure
+
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.0
        Added internal numpy interfaces for greater interoperability.
-
-    :group: datastructure
 
     Parameters
     ----------
@@ -616,14 +616,13 @@ class MaskGroup(base.MaskBase, ty.MutableMapping[str, MaskGeneric]):
     """Data structure to compose groups of masks over particle arrays.
     Can be nested to form complex hierarchies.
 
-    .. versionadded:: 0.1.0
+    :group: datastructure
 
+    .. versionadded:: 0.1.0
     .. versionchanged:: 0.2.6
        Changed ``bitwise_or`` and ``bitwise_and`` properties into
        methods.
        Added generic type hinting for elements within ``MaskGroup``.
-
-    :group: datastructure
 
     Parameters
     ----------
@@ -918,12 +917,12 @@ class PdgArray(base.ArrayBase):
     """Returns data structure containing PDG integer codes for particle
     data.
 
+    :group: datastructure
+
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.0
        Added internal numpy interfaces for greater interoperability.
-
-    :group: datastructure
 
     Parameters
     ----------
@@ -1183,6 +1182,8 @@ class PdgArray(base.ArrayBase):
 class MomentumArray(base.ArrayBase):
     """Data structure containing four-momentum of particle list.
 
+    :group: datastructure
+
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.0
@@ -1193,8 +1194,6 @@ class MomentumArray(base.ArrayBase):
 
     .. versionchanged:: 0.2.11
        Added ``mass_t`` attribute.
-
-    :group: datastructure
 
     Parameters
     ----------
@@ -1604,12 +1603,12 @@ class ColorArray(base.ArrayBase):
     """Returns data structure of color / anti-color pairs for particle
     shower.
 
+    :group: datastructure
+
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.0
        Added internal numpy interfaces for greater interoperability.
-
-    :group: datastructure
 
     Parameters
     ----------
@@ -1701,12 +1700,12 @@ class HelicityArray(base.ArrayBase):
     """Data structure containing helicity / polarisation values for
     particle set.
 
+    :group: datastructure
+
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.0
        Added internal numpy interfaces for greater interoperability.
-
-    :group: datastructure
 
     Parameters
     ----------
@@ -1788,12 +1787,12 @@ class HelicityArray(base.ArrayBase):
 class StatusArray(base.ArrayBase):
     """Data structure containing status values for particle set.
 
+    :group: datastructure
+
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.0
        Added internal numpy interfaces for greater interoperability.
-
-    :group: datastructure
 
     Parameters
     ----------
@@ -1995,9 +1994,9 @@ class ParticleSetSerialized(tyx.TypedDict, total=False):
 class ParticleSet(base.ParticleBase):
     """Composite of data structures containing particle set description.
 
-    .. versionadded:: 0.1.0
-
     :group: datastructure
+
+    .. versionadded:: 0.1.0
 
     Parameters
     ----------
@@ -2122,6 +2121,8 @@ class AdjacencyList(base.AdjacencyBase):
     """Describes relations between particles in particle set using a
     COO edge list, and provides methods to convert representation.
 
+    :group: datastructure
+
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.4
@@ -2129,8 +2130,6 @@ class AdjacencyList(base.AdjacencyBase):
 
     .. versionchanged:: 0.3.0
        Renamed "in" / "out" fields to "src" / "dst".
-
-    :group: datastructure
 
     Parameters
     ----------
@@ -2399,12 +2398,12 @@ class Graphicle:
     """Composite object, combining particle set data with relational
     information between particles.
 
+    :group: datastructure
+
     .. versionadded:: 0.1.0
 
     .. versionchanged:: 0.2.4
        Removed ``hard_vertex`` attribute.
-
-    :group: datastructure
 
     Parameters
     ----------

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -54,6 +54,7 @@ import numpy as np
 import numpy.typing as npt
 import typing_extensions as tyx
 from attr import Factory, asdict, cmp_using, define, field, setters
+from deprecation import deprecated
 from mcpid.lookup import PdgRecords
 from numpy.lib import recfunctions as rfn
 from rich.console import Console
@@ -812,6 +813,11 @@ class MaskGroup(base.MaskBase, ty.MutableMapping[str, MaskGeneric]):
                 "Please contact developers with a bug report."
             )
 
+    @deprecated(
+        deprecated_in="0.3.2",
+        removed_in="0.4.0",
+        details="Use MaskGroup.serialize() instead.",
+    )
     def to_dict(self) -> ty.Dict[str, base.BoolVector]:
         """Masks nested in a dictionary instead of a ``MaskGroup``."""
         return {key: val.data for key, val in self._mask_arrays.items()}

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -778,6 +778,7 @@ class MaskGroup(base.MaskBase, ty.MutableMapping[str, MaskGeneric]):
         return _mask_neq(self, other)
 
     def copy(self) -> "MaskGroup[MaskGeneric]":
+        """Copies the underlying data into a new MaskGroup instance."""
         mask_copies = map(op.methodcaller("copy"), self._mask_arrays.values())
         return self.__class__(
             cl.OrderedDict(zip(self._mask_arrays.keys(), mask_copies)),
@@ -1072,6 +1073,7 @@ class PdgArray(base.ArrayBase):
         self._data = values  # type: ignore
 
     def copy(self) -> "PdgArray":
+        """Copies the underlying data into a new PdgArray instance."""
         return self.__class__(self._data.copy())
 
     def mask(
@@ -1274,6 +1276,7 @@ class MomentumArray(base.ArrayBase):
         return _array_ne(self, other)
 
     def copy(self) -> "MomentumArray":
+        """Copies the underlying data into a new MomentumArray instance."""
         return self.__class__(self._data.copy())
 
     @property
@@ -1665,7 +1668,7 @@ class ColorArray(base.ArrayBase):
         self._data = values  # type: ignore
 
     def copy(self) -> "ColorArray":
-        """Produces a deepcopy of the data."""
+        """Copies the underlying data into a new ColorArray instance."""
         return self.__class__(self._data.copy())
 
     def __getitem__(self, key) -> "ColorArray":
@@ -1753,7 +1756,7 @@ class HelicityArray(base.ArrayBase):
         self._data = values  # type: ignore
 
     def copy(self) -> "HelicityArray":
-        """Produces a deepcopy of the data."""
+        """Copies the underlying data into a new HelicityArray instance."""
         return self.__class__(self._data.copy())
 
     def __getitem__(self, key) -> "HelicityArray":
@@ -1869,7 +1872,7 @@ class StatusArray(base.ArrayBase):
         self._data = values  # type: ignore
 
     def copy(self) -> "StatusArray":
-        """Returns a deepcopy of the data."""
+        """Copies the underlying data into a new StatusArray instance."""
         return self.__class__(self._data.copy())
 
     def in_range(
@@ -2053,7 +2056,7 @@ class ParticleSet(base.ParticleBase):
         return _composite_len(self)
 
     def copy(self) -> "ParticleSet":
-        """Produces a deepcopy of the data."""
+        """Copies the underlying data into a new ParticleSet instance."""
         return _composite_copy(self)
 
     @classmethod
@@ -2200,6 +2203,7 @@ class AdjacencyList(base.AdjacencyBase):
         return self.__class__(self._data[key].reshape(-1, 2))
 
     def copy(self) -> "AdjacencyList":
+        """Copies the underlying data into a new AdjacencyList instance."""
         return self.__class__(self._data.copy())
 
     @fn.cached_property
@@ -2436,6 +2440,7 @@ class Graphicle:
         return _composite_len(self)
 
     def copy(self) -> "Graphicle":
+        """Copies the underlying data into a new Graphicle instance."""
         return _composite_copy(self)
 
     @classmethod

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -1987,12 +1987,12 @@ class ParticleSetSerialized(tyx.TypedDict, total=False):
     .. versionadded:: 0.3.2
     """
 
-    pdg: ty.List[int]
-    pmu: ty.List[ty.Tuple[float, float, float, float]]
-    color: ty.List[ty.Tuple[int, int]]
-    helicity: ty.List[int]
-    status: ty.List[int]
-    final: ty.List[bool]
+    pdg: ty.Tuple[int, ...]
+    pmu: ty.Tuple[MomentumElement, ...]
+    color: ty.Tuple[ColorElement, ...]
+    helicity: ty.Tuple[int, ...]
+    status: ty.Tuple[int, ...]
+    final: ty.Tuple[bool, ...]
 
 
 @define
@@ -2390,13 +2390,13 @@ class GraphicleSerialized(tyx.TypedDict, total=False):
     .. versionadded:: 0.3.2
     """
 
-    pdg: ty.List[int]
-    pmu: ty.List[ty.Tuple[float, float, float, float]]
-    color: ty.List[ty.Tuple[int, int]]
-    helicity: ty.List[int]
-    status: ty.List[int]
-    final: ty.List[bool]
-    adj: ty.List[ty.Tuple[int, int]]
+    pdg: ty.Tuple[int, ...]
+    pmu: ty.Tuple[MomentumElement, ...]
+    color: ty.Tuple[ColorElement, ...]
+    helicity: ty.Tuple[int, ...]
+    status: ty.Tuple[int, ...]
+    final: ty.Tuple[bool, ...]
+    adj: ty.Tuple[VertexPair, ...]
 
 
 @define

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pyjet ==1.9.0",
     "rich",
     "deprecation",
+    "more-itertools >=7.2.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "rich",
     "deprecation",
     "more-itertools >=7.2.0",
+    "typing-extensions >=4.7.1",
 ]
 
 [project.urls]


### PR DESCRIPTION
Added methods to data structures which return serialisable objects. This should enable an easy interface for simple I/O, so users can write out to text files, _eg._ JSON.

Component data structures are given as tuples, and composite data structures are given as dictionaries, with their keys matching the attribute names of their components, and the values as the associated serialised tuples.