### PR TITLE
Added LaTeX output for PdgArray

### DIFF
--- a/graphicle/base.py
+++ b/graphicle/base.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 import numpy.typing as npt
+import typing_extensions as tyx
 
 __all__ = [
     "DoubleVector",

--- a/graphicle/base.py
+++ b/graphicle/base.py
@@ -31,16 +31,17 @@ __all__ = [
     "NumericalStabilityWarning",
 ]
 
-DoubleVector = npt.NDArray[np.float64]
-FloatVector = npt.NDArray[np.float32]
-ComplexVector = npt.NDArray[np.complex128]
-BoolVector = npt.NDArray[np.bool_]
-IntVector = npt.NDArray[np.int32]
-HalfIntVector = npt.NDArray[np.int16]
-ObjVector = npt.NDArray[np.object_]
-AnyVector = npt.NDArray[ty.Any]
-VoidVector = npt.NDArray[np.void]
-MaskLike = ty.Union["MaskBase", BoolVector]
+DoubleVector: tyx.TypeAlias = npt.NDArray[np.float64]
+FloatVector: tyx.TypeAlias = npt.NDArray[np.float32]
+ComplexVector: tyx.TypeAlias = npt.NDArray[np.complex128]
+BoolVector: tyx.TypeAlias = npt.NDArray[np.bool_]
+IntVector: tyx.TypeAlias = npt.NDArray[np.int32]
+HalfIntVector: tyx.TypeAlias = npt.NDArray[np.int16]
+ObjVector: tyx.TypeAlias = npt.NDArray[np.object_]
+StringVector: tyx.TypeAlias = npt.NDArray[np.str_]
+AnyVector: tyx.TypeAlias = npt.NDArray[ty.Any]
+VoidVector: tyx.TypeAlias = npt.NDArray[np.void]
+MaskLike: tyx.TypeAlias = ty.Union["MaskBase", BoolVector]
 DoubleUfunc = ty.TypeVar("DoubleUfunc", DoubleVector, np.float64)
 DataType = ty.TypeVar("DataType")
 

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -1239,14 +1239,14 @@ class PdgArray(base.ArrayBase):
         return props  # type: ignore
 
     @property
-    def name(self) -> base.ObjVector:
+    def name(self) -> base.StringVector:
         # 19 is the length of longest name
-        return self.__get_prop("name").astype("<U19")
+        return self.__get_prop("name").astype(np.str_)
 
     @property
-    def latex(self) -> ty.List[str]:
+    def latex(self) -> base.StringVector:
         # 32 is the length of longest name
-        return self.__get_prop("latex").tolist()
+        return self.__get_prop("latex").astype(np.str_)
 
     @property
     def charge(self) -> base.DoubleVector:
@@ -1265,8 +1265,8 @@ class PdgArray(base.ArrayBase):
         return range_arr
 
     @property
-    def quarks(self) -> base.ObjVector:
-        return self.__get_prop("quarks")
+    def quarks(self) -> base.StringVector:
+        return self.__get_prop("quarks").astype(np.str_)
 
     @property
     def width(self) -> base.DoubleVector:

--- a/graphicle/data.py
+++ b/graphicle/data.py
@@ -1038,6 +1038,9 @@ class PdgArray(base.ArrayBase):
     .. versionchanged:: 0.2.0
        Added internal numpy interfaces for greater interoperability.
 
+    .. versionchanged:: 0.4.1
+       ``name`` property now gives unicode array. latex property added.
+
     Parameters
     ----------
     data : sequence[int]
@@ -1045,7 +1048,7 @@ class PdgArray(base.ArrayBase):
 
     Attributes
     ----------
-    name : ndarray[object]
+    name : ndarray[unicode]
         String representation of particle names.
     charge : ndarray[float64]
         Charge for each particle in elementary units.
@@ -1069,6 +1072,8 @@ class PdgArray(base.ArrayBase):
         Spatial parity for each particle.
     charge_parity : ndarray[float64]
         Charge parity for each particle.
+    latex : list[str]
+        LaTeX compatible representation of particle names.
 
     Methods
     -------
@@ -1235,7 +1240,13 @@ class PdgArray(base.ArrayBase):
 
     @property
     def name(self) -> base.ObjVector:
-        return self.__get_prop("name")
+        # 19 is the length of longest name
+        return self.__get_prop("name").astype("<U19")
+
+    @property
+    def latex(self) -> ty.List[str]:
+        # 32 is the length of longest name
+        return self.__get_prop("latex").tolist()
 
     @property
     def charge(self) -> base.DoubleVector:


### PR DESCRIPTION
LaTeX output for `PdgArray` included as a `PdgArray.latex` property. Additionally, `StringVector` type alias has been used for `np.str_` array outputs, rather than `np.object` arrays.