### PR TITLE
Added automated testing on ARM and Windows architectures #188

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
             python=${{ matrix.pyver }}
             pytest>=6.2.5
           init-shell: bash
-          cache-environment: false
+          cache-environment: true
           post-cleanup: 'all'
 
       - name: Install graphicle

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13]
-        pyver: ["3.8", "3.9", "3.10", "3.11"]
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        pyver: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - uses: mamba-org/setup-micromamba@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,8 @@ jobs:
           create-args: >-
             python=${{ matrix.pyver }}
             pytest>=6.2.5
-            libtool
           init-shell: bash
-          cache-environment: true
+          cache-environment: false
           post-cleanup: 'all'
 
       - name: Install graphicle


### PR DESCRIPTION
Since `fastjet` is now an optional dependency (see #185), testing can resume on Windows-latest and macOS-latest.